### PR TITLE
fix: merge assignment responses with shift skill data in detail view

### DIFF
--- a/client/app/(authenticated)/manager/shifts/[shiftId]/shift-detail.client.tsx
+++ b/client/app/(authenticated)/manager/shifts/[shiftId]/shift-detail.client.tsx
@@ -35,7 +35,7 @@ import {
   useAssignStaff,
   useRemoveAssignment,
 } from '@/hooks/use-assignments';
-import { useLocations } from '@/hooks/use-reference-data';
+import { useManagerLocations } from '@/hooks/use-reference-data';
 import type {
   AssignmentResponseDto,
   SlotAssignmentsResponseDto,
@@ -68,11 +68,24 @@ export default function ShiftDetailView({ shiftId }: { shiftId: number }) {
     refetch: refetchShift,
   } = useShift(shiftId);
   const slotIds = shift?.skills.map((s) => s.id) || [];
-  const { data: slots = [], isLoading: isLoadingSlots } = useAllSlotAssignments(
-    shiftId,
-    slotIds,
+  const { data: assignmentResponses = [], isLoading: isLoadingSlots } =
+    useAllSlotAssignments(shiftId, slotIds);
+
+  const slots: SlotAssignmentsResponseDto[] = useMemo(
+    () =>
+      shift
+        ? shift.skills.map((skill, i) => ({
+            slotId: skill.id,
+            skillId: skill.skillId,
+            skillName: skill.skillName,
+            headcount: skill.headcount,
+            assignedCount: skill.assignedCount,
+            assignments: assignmentResponses[i] ?? [],
+          }))
+        : [],
+    [shift, assignmentResponses],
   );
-  const { data: locations = [] } = useLocations();
+  const { data: locations = [] } = useManagerLocations();
 
   const [activeSlotId, setActiveSlotId] = useState<number | null>(null);
 

--- a/client/app/(authenticated)/manager/shifts/shifts-list.client.tsx
+++ b/client/app/(authenticated)/manager/shifts/shifts-list.client.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Plus, Trash2, X, Loader2 } from 'lucide-react';
+import { Eye, Plus, Trash2, X, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -368,9 +368,9 @@ export default function ShiftsList() {
                             prev.map((s) =>
                               s.id === slot.id
                                 ? {
-                                  ...s,
-                                  headcount: parseInt(e.target.value) || 1,
-                                }
+                                    ...s,
+                                    headcount: parseInt(e.target.value) || 1,
+                                  }
                                 : s,
                             ),
                           );
@@ -422,7 +422,7 @@ export default function ShiftsList() {
                 <TableHead>Time</TableHead>
                 <TableHead>State</TableHead>
                 <TableHead>Skill Slots</TableHead>
-                <TableHead className="w-[100px]"></TableHead>
+                <TableHead className="w-[160px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -465,21 +465,33 @@ export default function ShiftsList() {
                       </div>
                     </TableCell>
                     <TableCell>
-                      {shift.state !== 'CANCELLED' && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-muted-foreground hover:text-destructive"
-                          disabled={cancellingId === shift.id}
-                          onClick={() => handleCancel(shift.id)}
-                        >
-                          {cancellingId === shift.id ? (
-                            <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                          ) : (
-                            <Trash2 className="w-3.5 h-3.5" />
-                          )}
-                        </Button>
-                      )}
+                      <div className="flex gap-1.5">
+                        <Link href={`/manager/shifts/${shift.id}`}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="gap-1.5 h-7"
+                          >
+                            <Eye className="w-3 h-3" />
+                            View
+                          </Button>
+                        </Link>
+                        {shift.state !== 'CANCELLED' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-muted-foreground hover:text-destructive h-7 px-2"
+                            disabled={cancellingId === shift.id}
+                            onClick={() => handleCancel(shift.id)}
+                          >
+                            {cancellingId === shift.id ? (
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            ) : (
+                              <Trash2 className="w-3.5 h-3.5" />
+                            )}
+                          </Button>
+                        )}
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))

--- a/client/hooks/use-assignments.ts
+++ b/client/hooks/use-assignments.ts
@@ -4,14 +4,14 @@ import { apiClient } from '@/lib/api-client';
 import type {
   ApproveSwapDropDto,
   CreateAssignmentDto,
+  AssignmentResponseDto,
   EligibleStaffDto,
-  SlotAssignmentsResponseDto,
 } from '@/types/scheduling';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 export function useAssignments(shiftId: number, slotId: number) {
-  return useQuery<SlotAssignmentsResponseDto, Error>({
+  return useQuery<AssignmentResponseDto[], Error>({
     queryKey: ['assignments', shiftId, slotId],
     queryFn: () => apiClient.getAssignments(shiftId, slotId),
     enabled: shiftId > 0 && slotId > 0,

--- a/client/lib/api-client.ts
+++ b/client/lib/api-client.ts
@@ -1,5 +1,6 @@
 import type {
   ApproveSwapDropDto,
+  AssignmentResponseDto,
   CreateAssignmentDto,
   CreateShiftDto,
   EligibleStaffDto,
@@ -8,7 +9,6 @@ import type {
   RequestSwapDto,
   ShiftResponseDto,
   SkillResponseDto,
-  SlotAssignmentsResponseDto,
   StaffAvailabilityExceptionResponseDto,
   StaffAvailabilityResponseDto,
   StaffScheduleEntryDto,
@@ -314,7 +314,7 @@ export const apiClient = {
   async getAssignments(
     shiftId: number,
     slotId: number,
-  ): Promise<SlotAssignmentsResponseDto> {
+  ): Promise<AssignmentResponseDto[]> {
     const response = await fetch(
       `${serverUrl}/shifts/${shiftId}/skills/${slotId}/assignments`,
       {


### PR DESCRIPTION
- Fixes a type mismatch where the assignments API returns `AssignmentResponseDto[]` but the client expected `SlotAssignmentsResponseDto`, causing a runtime error accessing .assignments on an array. 
- Also adds a View button to the shifts list and fixes useManagerLocations on the detail page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "View" action button to the shifts list for quick navigation to shift details.

* **Refactor**
  * Updated internal data handling for location and assignment information across the shifts interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->