### PR TITLE
fix: make LOCKED a sticky terminal state for shifts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ npm run client:start     # Start client (production mode)
 ```bash
 npm run build              # Build with NestJS compiler (SWC)
 npm run lint               # Lint with ESLint (fixes issues)
-npm run test               # Run all unit tests
+npm run test -- --runInBand  # Run all unit tests
 npm run test:watch         # Run tests in watch mode
 npm run test:cov           # Run tests with coverage
 npm run test -- --testNamePattern="test name"   # Run single test by name

--- a/server/src/scheduling/repositories/shift.repository.ts
+++ b/server/src/scheduling/repositories/shift.repository.ts
@@ -134,6 +134,10 @@ export class ShiftRepository {
     state: ShiftState,
   ): Promise<Result<void, Error>> {
     try {
+      const shift = await this.shiftRepo.findOneBy({ id });
+      if (shift?.state === ShiftState.LOCKED) {
+        return Result.ok(undefined);
+      }
       await this.shiftRepo.update(id, { state });
       return Result.ok(undefined);
     } catch (e) {

--- a/server/src/scheduling/services/assignment.service.spec.ts
+++ b/server/src/scheduling/services/assignment.service.spec.ts
@@ -275,6 +275,32 @@ describe('AssignmentService (Integration)', () => {
       });
       expect(events).toHaveLength(0);
     });
+
+    it('creates assignment but keeps shift LOCKED', async () => {
+      const { employee } = await createEmployee();
+      const location = await createLocation();
+      const skill = await createSkill();
+      await certifyEmployee(employee.id, location.id, skill.id);
+
+      const shift = await dataSource.getRepository(Shift).save({
+        locationId: location.id,
+        startTime: new Date('2026-03-24T10:00:00Z'),
+        endTime: new Date('2026-03-24T18:00:00Z'),
+        state: ShiftState.LOCKED,
+      });
+      const shiftSkill = await dataSource.getRepository(ShiftSkillEntity).save({
+        shiftId: shift.id,
+        skillId: skill.id,
+        headcount: 1,
+      });
+
+      await assignmentService.assignStaff(shift.id, shiftSkill.id, employee.id);
+
+      const updatedShift = await dataSource.getRepository(Shift).findOneBy({
+        id: shift.id,
+      });
+      expect(updatedShift?.state).toBe(ShiftState.LOCKED);
+    });
   });
 
   describe('removeAssignment', () => {
@@ -373,6 +399,42 @@ describe('AssignmentService (Integration)', () => {
       await expect(
         assignmentService.removeAssignment(shift.id, shiftSkill.id, 99999),
       ).rejects.toThrow('Assignment not found');
+    });
+
+    it('cancels assignment but keeps shift LOCKED', async () => {
+      const { employee } = await createEmployee();
+      const location = await createLocation();
+      const skill = await createSkill();
+      await certifyEmployee(employee.id, location.id, skill.id);
+
+      const shift = await dataSource.getRepository(Shift).save({
+        locationId: location.id,
+        startTime: new Date('2026-03-24T10:00:00Z'),
+        endTime: new Date('2026-03-24T18:00:00Z'),
+        state: ShiftState.LOCKED,
+      });
+      const shiftSkill = await dataSource.getRepository(ShiftSkillEntity).save({
+        shiftId: shift.id,
+        skillId: skill.id,
+        headcount: 1,
+      });
+
+      const assignment = await dataSource.getRepository(Assignment).save({
+        staffMemberId: employee.id,
+        shiftSkillId: shiftSkill.id,
+        state: AssignmentState.ASSIGNED,
+      });
+
+      await assignmentService.removeAssignment(
+        shift.id,
+        shiftSkill.id,
+        assignment.id,
+      );
+
+      const updatedShift = await dataSource.getRepository(Shift).findOneBy({
+        id: shift.id,
+      });
+      expect(updatedShift?.state).toBe(ShiftState.LOCKED);
     });
   });
 

--- a/server/src/scheduling/services/shift.service.spec.ts
+++ b/server/src/scheduling/services/shift.service.spec.ts
@@ -274,6 +274,27 @@ describe('ShiftService (Integration)', () => {
       );
     });
 
+    it('rejects cancel for locked shift', async () => {
+      const location = await createLocation();
+      const skill = await createSkill();
+
+      const shift = await dataSource.getRepository(Shift).save({
+        locationId: location.id,
+        startTime: new Date('2026-03-24T10:00:00Z'),
+        endTime: new Date('2026-03-24T18:00:00Z'),
+        state: ShiftState.LOCKED,
+      });
+      await dataSource.getRepository(ShiftSkill).save({
+        shiftId: shift.id,
+        skillId: skill.id,
+        headcount: 1,
+      });
+
+      await expect(shiftService.cancelShift(shift.id)).rejects.toThrow(
+        'Cannot cancel shift in state LOCKED',
+      );
+    });
+
     it('cancels pending swap requests when shift is cancelled', async () => {
       const location = await createLocation();
       const skill = await createSkill();


### PR DESCRIPTION
Prevent deriveFillState from silently overwriting LOCKED shifts to OPEN/PARTIALLY_FILLED after assignment mutations. updateState now no-ops when the current state is LOCKED, preserving schedule context.

Add missing test for cancel rejection on locked shifts and new integration tests verifying assignment creation/removal keeps shifts in LOCKED state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shifts in LOCKED state are now prevented from undergoing state modifications during staff assignments and other operations.

* **Tests**
  * Added test cases verifying locked shifts remain protected when assigning staff, removing assignments, and during cancellation attempts.

* **Chores**
  * Updated test execution configuration for improved test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->